### PR TITLE
Filter out pentests from Intigriti programs

### DIFF
--- a/pkg/platforms/intigriti/intigriti.go
+++ b/pkg/platforms/intigriti/intigriti.go
@@ -94,7 +94,7 @@ func GetAllProgramsScope(token string, bbpOnly bool, pvtOnly bool, categories st
 		log.Fatal("HTTP request failed: ", err)
 	}
 
-	data := gjson.GetMany(res.BodyString, "#.companyHandle", "#.handle", "#.maxBounty.value", "#.confidentialityLevel")
+	data := gjson.GetMany(res.BodyString, "#(type==1)#.companyHandle", "#(type==1)#.handle", "#(type==1)#.maxBounty.value", "#(type==1)#.confidentialityLevel")
 
 	allCompanyHandles := data[0].Array()
 	allHandles := data[1].Array()


### PR DESCRIPTION
`bbscope it` breaks when a user has some Intigriti hybrid pentests active.
The reason is that API call (https://api.intigriti.com/core/researcher/programs) to get list of programs  
has active pentests attached at the end of JSON array:
```json
[{"type":1,"minBounty":{"value":0.0,"currency":"EUR"},"maxBounty":{"value":3500.0,"currency":"EUR"},"programId":"f65f73f6-e60f-405e-a7fd-xxxxxxxxxx","status":3,"confidentialityLevel":1},


{"baseBounty":{"value":1600.0,"currency":"USD"},"bountyPool":{"value":5600.0,"currency":"USD"},"testWindowStartsAt":1696420800,"testWindowEndsAt":1697630400,"expectedEffort":144000,"type":2,"programId":"678fffc1-c455-452d-ad72-xxxxxxxxxxxxxxxx","status":1002,"confidentialityLevel":2}
```
Structure of JSON describing a pentest is different then for standard program (`maxBounty` field is missing).

The solution is to filter JSON array on `type==1` which will only return regular programs.
